### PR TITLE
[driver] Updated Gazebo API for Gazebo 9 and above

### DIFF
--- a/Deps/ros/CMakeLists.txt
+++ b/Deps/ros/CMakeLists.txt
@@ -7,7 +7,7 @@ if (ENABLE_ROS)
 	
 	    MESSAGE("*** ROS LIBRARIES FOUND : ${roscpp_INCLUDE_DIRS}")
 	
-	    SET (CMAKE_PREFIX_PATH /opt/ros/melodic)
+	    SET (CMAKE_PREFIX_PATH /opt/ros/$ENV{ROS_DISTRO})
 	
 	    usePython(2)
 	    set (CATKIN_BUILD_BINARY_PACKAGE 1) #doesn't add ROS environment files to package

--- a/src/drivers/gazebo/plugins/flyingKinect/include/quadrotor/quadrotorsensors.hh
+++ b/src/drivers/gazebo/plugins/flyingKinect/include/quadrotor/quadrotorsensors.hh
@@ -84,7 +84,7 @@ private:
 
 public:
     cv::Mat img[NUM_CAMS];
-    gazebo::math::Pose pose;
+    ignition::math::Pose3d pose;
     double altitude;
 
 };

--- a/src/drivers/gazebo/plugins/flyingKinect/src/cameraproxy.cc
+++ b/src/drivers/gazebo/plugins/flyingKinect/src/cameraproxy.cc
@@ -49,7 +49,7 @@ CameraProxy::setActive(int id){
     /// deactivate previous
     if (active_camera != -1){
         cameras[active_camera]->SetActive(false);
-        cameras[active_camera]->DisconnectUpdated(active_sub);
+        // cameras[active_camera]->DisconnectUpdated(active_sub);
     }
 
     /// active new
@@ -78,7 +78,7 @@ void
 CameraProxy::_on_cam_bootstrap(){
     lock.lock();
 
-    cameras[active_camera]->DisconnectUpdated(active_sub);
+    // cameras[active_camera]->DisconnectUpdated(active_sub);
 
     img = _createImageWrapper(cameras[active_camera], active_camera);
 

--- a/src/drivers/gazebo/plugins/flyingKinect/src/interfaces/camerai.cpp
+++ b/src/drivers/gazebo/plugins/flyingKinect/src/interfaces/camerai.cpp
@@ -41,7 +41,7 @@ CameraI::onCameraSensorBoostrap(){
 
     std::cout<<"CameraI::onCameraSensorBoostrap()"<<std::endl;
 
-    sensor->cam[cam_id]->DisconnectUpdated(cameraSensorConnection);
+    // sensor->cam[cam_id]->DisconnectUpdated(cameraSensorConnection);
 
     imgCached = sensor->img[cam_id].clone();
 

--- a/src/drivers/gazebo/plugins/flyingKinect/src/quadrotorsensors.cc
+++ b/src/drivers/gazebo/plugins/flyingKinect/src/quadrotorsensors.cc
@@ -60,7 +60,7 @@ QuadRotorSensors::Load(ModelPtr model){
     }
 
     // weak-fix for sonar value at boostrap (1/2)
-    altitude = model->GetWorldPose().pos.z;
+    altitude = model->WorldPose().Pos().Z();
 }
 
 
@@ -123,7 +123,7 @@ QuadRotorSensors::_on_cam(int id){
         uint32_t w = cam[id]->ImageWidth();
         img[id] = cv::Mat(h, w, CV_8UC3, (uint8_t*)data);
 
-        cam[id]->DisconnectUpdated(sub_cam[id]); // close connection
+        //cam[id]->DisconnectUpdated(sub_cam[id]); // close connection
     }
 }
 
@@ -146,7 +146,7 @@ QuadRotorSensors::_on_sonar(){
 
 void
 QuadRotorSensors::_on_imu(){
-    pose = model->GetWorldPose();
-    pose.rot = imu->Orientation();
+    pose = model->WorldPose();
+    pose.Rot() = imu->Orientation();
 //    std::cout<<pose<<std::endl;
 }

--- a/src/drivers/gazebo/plugins/formula1/CMakeLists.txt
+++ b/src/drivers/gazebo/plugins/formula1/CMakeLists.txt
@@ -43,7 +43,7 @@ set_target_properties(formula1plugin PROPERTIES COMPILE_FLAGS "${GAZEBO_CXX_FLAG
 # Ice
 target_link_libraries(formula1plugin
         Ice
-        IceUtil
+        # IceUtil
         JderobotInterfaces
         ${ZeroCIce_LIBRARIES}
         ${easyiceconfig_LIBRARIES}

--- a/src/drivers/gazebo/plugins/formula1/include/formula1/formula1control.hh
+++ b/src/drivers/gazebo/plugins/formula1/include/formula1/formula1control.hh
@@ -63,7 +63,7 @@ public:
     void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr _sdf);
     void Init(Formula1Sensors* sensors);
     void OnUpdate(const gazebo::common::UpdateInfo & _info);
-    void teleport(gazebo::math::Pose pose);
+    void teleport(ignition::math::Pose3d pose);
 
 private:
     gazebo::event::ConnectionPtr updateConnection;

--- a/src/drivers/gazebo/plugins/formula1/include/formula1/formula1plugin.hh
+++ b/src/drivers/gazebo/plugins/formula1/include/formula1/formula1plugin.hh
@@ -24,7 +24,7 @@
 
 #include <gazebo/gazebo.hh>
 #include <gazebo/common/common.hh>
-#include <gazebo/math/Pose.hh>
+#include <ignition/math/Pose3.hh>
 
 #include <formula1/formula1sensors.hh>
 #include <formula1/formula1control.hh>

--- a/src/drivers/gazebo/plugins/formula1/include/formula1/formula1sensors.hh
+++ b/src/drivers/gazebo/plugins/formula1/include/formula1/formula1sensors.hh
@@ -79,7 +79,7 @@ private:
 public:
     cv::Mat img[NUM_CAMS];
     std::vector<float> laserValues;
-    gazebo::math::Pose pose;
+    ignition::math::Pose3d pose;
 
     double position;
 };

--- a/src/drivers/gazebo/plugins/formula1/src/cameraproxy.cc
+++ b/src/drivers/gazebo/plugins/formula1/src/cameraproxy.cc
@@ -81,7 +81,7 @@ void
 CameraProxy::_on_cam_bootstrap(){
     lock.lock();
 
-    cameras[active_camera]->DisconnectUpdated(active_sub);
+    // cameras[active_camera]->DisconnectUpdated(active_sub);
 
     img = _createImageWrapper(cameras[active_camera], active_camera);
 

--- a/src/drivers/gazebo/plugins/formula1/src/formula1plugin.cc
+++ b/src/drivers/gazebo/plugins/formula1/src/formula1plugin.cc
@@ -25,7 +25,7 @@ GZ_REGISTER_MODEL_PLUGIN(formula1::Formula1Plugin)
 
 using namespace formula1;
 using namespace gazebo::physics;
-using namespace gazebo::math;
+using namespace ignition::math;
 using namespace gazebo::event;
 using namespace gazebo::common;
 

--- a/src/drivers/gazebo/plugins/formula1/src/formula1sensors.cc
+++ b/src/drivers/gazebo/plugins/formula1/src/formula1sensors.cc
@@ -54,7 +54,7 @@ Formula1Sensors::Load(ModelPtr model){
         if (name.find("cam_formula1_right") != std::string::npos)
             cam[CAM_RIGHT] = std::static_pointer_cast<CameraSensor>(s);
 
-        pose = model->GetWorldPose();
+        pose = model->WorldPose();
     }
 }
 
@@ -75,7 +75,7 @@ Formula1Sensors::Init(){
     }else
         std::cerr << _log_prefix << "\t laser was not connected (NULL pointer)" << std::endl;
 
-    ONDEBUG_INFO(std::cout << _log_prefix << "Initial Pose [x,y,z] " << pose.pos.x << ", " << pose.pos.y << ", " << pose.pos.z << std::endl;)
+    ONDEBUG_INFO(std::cout << _log_prefix << "Initial Pose [x,y,z] " << pose.Pos()[0] << ", " << pose.Pos()[1] << ", " << pose.Pos()[2] << std::endl;)
 
     //Pose3d
     updatePose = gazebo::event::Events::ConnectWorldUpdateBegin(
@@ -115,7 +115,7 @@ Formula1Sensors::_on_cam(int id){
         uint32_t w = cam[id]->ImageWidth();
         img[id] = cv::Mat(h, w, CV_8UC3, (uint8_t*)data);
 
-        cam[id]->DisconnectUpdated(sub_cam[id]); // close connection
+        // cam[id]->DisconnectUpdated(sub_cam[id]); // close connection
      }
 }
 
@@ -142,5 +142,5 @@ Formula1Sensors::_on_laser(){
 
 void
 Formula1Sensors::OnUpdate(const gazebo::common::UpdateInfo & /*_info*/){
-    pose = model->GetWorldPose();
+    pose = model->WorldPose();
 }

--- a/src/drivers/gazebo/plugins/formula1/src/interfaces/camerai.cpp
+++ b/src/drivers/gazebo/plugins/formula1/src/interfaces/camerai.cpp
@@ -41,7 +41,7 @@ CameraI::onCameraSensorBoostrap(){
 
     std::cout<<"CameraI::onCameraSensorBoostrap()"<<std::endl;
 
-    sensor->cam[cam_id]->DisconnectUpdated(cameraSensorConnection);
+    // sensor->cam[cam_id]->DisconnectUpdated(cameraSensorConnection);
 
     imgCached = sensor->img[cam_id].clone();
 

--- a/src/drivers/gazebo/plugins/formula1/src/interfaces/pose3di.cpp
+++ b/src/drivers/gazebo/plugins/formula1/src/interfaces/pose3di.cpp
@@ -34,24 +34,24 @@ Pose3DI::~Pose3DI ()
 
 Pose3DDataPtr
 Pose3DI::getPose3DData ( const Ice::Current& ){
-    gazebo::math::Pose pose = sensor->pose;
+    // ignition::math::Pose3<double> pose(sensor->pose.pos.x,sensor->pose.pos.y,sensor->pose.pos.z,sensor->pose.rot.w,sensor->pose.rot.x,sensor->pose.rot.y,sensor->pose.rot.z);
+    ignition::math::Pose3d pose(sensor->pose);
 
-    data->x = pose.pos.x;
-    data->y = pose.pos.y;
-    data->z = pose.pos.z;
+    data->x = pose.Pos()[0];
+    data->y = pose.Pos()[1];
+    data->z = pose.Pos()[2];
     data->h = 1;
-    data->q0 = pose.rot.w;
-    data->q1 = pose.rot.x;
-    data->q2 = pose.rot.y;
-    data->q3 = pose.rot.z;
+    data->q0 = pose.Rot().W();
+    data->q1 = pose.Rot().X();
+    data->q2 = pose.Rot().Y();
+    data->q3 = pose.Rot().Z();
 
     return data;
 }
 
 Ice::Int
 Pose3DI::setPose3DData ( const jderobot::Pose3DDataPtr & data, const Ice::Current& ){
-    gazebo::math::Pose pose(gazebo::math::Vector3(data->x, data->y, data->z),
-                            gazebo::math::Quaternion(data->q0, data->q1, data->q2, data->q3));
+    ignition::math::Pose3d pose(data->x, data->y, data->z,data->q0, data->q1, data->q2, data->q3);
     control->teleport(pose);
     return 0;
 }

--- a/src/drivers/gazebo/plugins/gymkhana/wall1.cc
+++ b/src/drivers/gazebo/plugins/gymkhana/wall1.cc
@@ -9,7 +9,7 @@ namespace gazebo
 {
 	class Wall1 : public ModelPlugin {
 
-		private: math::Pose pose;
+		private: ignition::math::Pose3d pose;
 		private: bool flag;
 		private: double vel1; 
 		private: double vel2; 
@@ -26,21 +26,21 @@ namespace gazebo
 		}
 
 		public: void OnUpdate(const common::UpdateInfo & ) {
-			pose = this->model->GetWorldPose();
+			pose = this->model->WorldPose();
 
 			if  (flag) {
-				this->model->SetLinearVel(math::Vector3(this->vel1, 0, 0));
+				this->model->SetLinearVel(ignition::math::Vector3d(this->vel1, 0, 0));
 			}
-			if ( pose.pos.x >=4 ) {
-				pose.pos.x = 4;
+			if ( pose.Pos()[0] >=4 ) {
+				pose.Pos()[0] = 4;
 				this->model->SetWorldPose(pose);
 				flag = false;
 			}
 			if (!flag) {
-				this->model->SetLinearVel(math::Vector3(this->vel2, 0, 0));
+				this->model->SetLinearVel(ignition::math::Vector3d(this->vel2, 0, 0));
 			}	
-			if ( pose.pos.x <=-4 ) {
-				pose.pos.x = -4;
+			if ( pose.Pos()[0] <=-4 ) {
+				pose.Pos()[0] = -4;
 				this->model->SetWorldPose(pose);
 				flag = true;
 			}

--- a/src/drivers/gazebo/plugins/gymkhana/wall2.cc
+++ b/src/drivers/gazebo/plugins/gymkhana/wall2.cc
@@ -9,7 +9,7 @@ namespace gazebo
 {
 	class Wall2 : public ModelPlugin {
 
-		private: math::Pose pose;
+		private: ignition::math::Pose3d pose;
 		private: bool flag;
 		private: double vel1; 
 		private: double vel2; 
@@ -25,21 +25,21 @@ namespace gazebo
 		}
 
 		public: void OnUpdate(const common::UpdateInfo & ) {
-			pose = this->model->GetWorldPose();
+			pose = this->model->WorldPose();
 
 			if  (flag) {
-				this->model->SetLinearVel(math::Vector3(0, 0, this->vel1));
+				this->model->SetLinearVel(ignition::math::Vector3d(0, 0, this->vel1));
 			}
-			if ( pose.pos.z >= 2.8 ) {
-				pose.pos.z = 2.8;
+			if ( pose.Pos()[2] >= 2.8 ) {
+				pose.Pos()[2] = 2.8;
 				this->model->SetWorldPose(pose);
 				flag = false;
 			}
 			if (!flag) {
-				this->model->SetLinearVel(math::Vector3(0, 0, this->vel2));
+				this->model->SetLinearVel(ignition::math::Vector3d(0, 0, this->vel2));
 			}	
-			if ( pose.pos.z <= 0) {
-				pose.pos.z = 0;
+			if ( pose.Pos()[2] <= 0) {
+				pose.Pos()[2] = 0;
 				this->model->SetWorldPose(pose);
 				flag = true;
 			}

--- a/src/drivers/gazebo/plugins/gymkhana/wall3.cc
+++ b/src/drivers/gazebo/plugins/gymkhana/wall3.cc
@@ -9,7 +9,7 @@ namespace gazebo
 {
 	class Wall3 : public ModelPlugin {
 
-		private: math::Pose pose;
+		private: ignition::math::Pose3d pose;
 		private: bool flag;
 		private: double vel1; 
 		private: double vel2; 
@@ -26,21 +26,21 @@ namespace gazebo
 		}
 
 		public: void OnUpdate(const common::UpdateInfo & ) {
-			pose = this->model->GetWorldPose();
+			pose = this->model->WorldPose();
 
 			if  (flag) {
-				this->model->SetLinearVel(math::Vector3(this->vel1, 0, 0));
+				this->model->SetLinearVel(ignition::math::Vector3d(this->vel1, 0, 0));
 			}
-			if ( pose.pos.x >=4 ) {
-				pose.pos.x = 4;
+			if ( pose.Pos()[0] >=4 ) {
+				pose.Pos()[0] = 4;
 				this->model->SetWorldPose(pose);
 				flag = false;
 			}
 			if (!flag) {
-				this->model->SetLinearVel(math::Vector3(this->vel2, 0, 0));
+				this->model->SetLinearVel(ignition::math::Vector3d(this->vel2, 0, 0));
 			}	
-			if ( pose.pos.x <= 1.25 ) {
-				pose.pos.x = 1.25;
+			if ( pose.Pos()[0] <= 1.25 ) {
+				pose.Pos()[0] = 1.25;
 				this->model->SetWorldPose(pose);
 				flag = true;
 			}

--- a/src/drivers/gazebo/plugins/gymkhana/wall4.cc
+++ b/src/drivers/gazebo/plugins/gymkhana/wall4.cc
@@ -9,7 +9,7 @@ namespace gazebo
 {
   	class Wall4 : public ModelPlugin {
 
-		private: math::Pose pose;
+		private: ignition::math::Pose3d pose;
   		private: bool flag;
 		private: double vel1; 
 		private: double vel2; 
@@ -26,21 +26,21 @@ namespace gazebo
 		}
 
     		public: void OnUpdate(const common::UpdateInfo & ) {
-			pose = this->model->GetWorldPose();
+			pose = this->model->WorldPose();
 
 			if  (flag) {
-				this->model->SetLinearVel(math::Vector3(this->vel2, 0, 0));
+				this->model->SetLinearVel(ignition::math::Vector3d(this->vel2, 0, 0));
 			}
-			if ( pose.pos.x <=-4 ) {
-			        pose.pos.x = -4;
+			if ( pose.Pos()[0] <=-4 ) {
+			        pose.Pos()[0] = -4;
 			        this->model->SetWorldPose(pose);
 				flag = false;
 			}
 			if (!flag) {
-				this->model->SetLinearVel(math::Vector3(this->vel1, 0, 0));
+				this->model->SetLinearVel(ignition::math::Vector3d(this->vel1, 0, 0));
 			}	
-			if ( pose.pos.x >= -1.25 ) {
-			        pose.pos.x = -1.25;
+			if ( pose.Pos()[0] >= -1.25 ) {
+			        pose.Pos()[0] = -1.25;
 			        this->model->SetWorldPose(pose);
 				flag = true;
 			}

--- a/src/drivers/gazebo/plugins/holo_car/holoCarMotors.cc
+++ b/src/drivers/gazebo/plugins/holo_car/holoCarMotors.cc
@@ -25,7 +25,7 @@ namespace gazebo
     {
         this->model = _model;
         this->node = transport::NodePtr(new transport::Node());
-        this->node->Init(this->model->GetWorld()->GetName());
+        this->node->Init(this->model->GetWorld()->Name());
 
         this->updateConnection = event::Events::ConnectWorldUpdateBegin(
                                     boost::bind(&Motors::OnUpdate, this));
@@ -64,14 +64,15 @@ namespace gazebo
 
         }
 
-        float z = model->GetRelativeLinearVel().z;
-        math::Vector3 vel(robotMotors.v,0,z);
+        float z = model->RelativeLinearVel()[2];
+        ignition::math::Vector3d vel(robotMotors.v,0,z);
 
-        math::Quaternion rot = model->GetWorldPose().rot;
-        vel = rot.GetAsMatrix3()*vel;
+        ignition::math::Quaternion<double> rot = model->WorldPose().Rot();
+        ignition::math::Matrix3d inter_mat(rot);
+        vel = inter_mat*vel;
 
         this->model->SetLinearVel(vel);
-        this->model->SetAngularVel(math::Vector3(0,0,robotMotors.w));
+        this->model->SetAngularVel(ignition::math::Vector3d(0,0,robotMotors.w));
     }
 
     class MotorsI : virtual public jderobot::Motors {

--- a/src/drivers/gazebo/plugins/holo_car/holoCarMotors.h
+++ b/src/drivers/gazebo/plugins/holo_car/holoCarMotors.h
@@ -1,6 +1,6 @@
 #include <boost/bind.hpp>
 #include <gazebo/gazebo.hh>
-#include <gazebo/math/Angle.hh>
+#include <ignition/math/Angle.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/transport/transport.hh>

--- a/src/drivers/gazebo/plugins/holo_car/holoCarPose3d.cc
+++ b/src/drivers/gazebo/plugins/holo_car/holoCarPose3d.cc
@@ -37,17 +37,17 @@ namespace gazebo {
             pthread_create(&thr_gui, NULL, &Pose3DICE, (void*) this);
         }
 
-        position = model->GetWorldPose();
-        this->initial_q = position.rot;
-
+        position = model->WorldPose();
+        this->initial_q = position.Rot();
 
         pthread_mutex_lock(&mutex);
-        robotPose3D.x = position.pos.x;
-        robotPose3D.y = position.pos.y;
-        robotPose3D.q0 = position.rot.w;
-        robotPose3D.q1 = position.rot.x;
-        robotPose3D.q2 = position.rot.y;
-        robotPose3D.q3 = position.rot.z;
+        robotPose3D.x = position.Pos()[0];
+        robotPose3D.y = position.Pos()[1];
+        robotPose3D.q0 = position.Rot().W();
+        robotPose3D.q1 = position.Rot().X();
+        robotPose3D.q2 = position.Rot().Y();
+        robotPose3D.q3 = position.Rot().Z();
+
         pthread_mutex_unlock(&mutex);
 
     }
@@ -64,18 +64,18 @@ namespace gazebo {
         
         virtual int setPose3DData(const jderobot::Pose3DDataPtr&  Pose3DData,
         						     const Ice::Current&) {
-             math::Pose position = this->pose->getModel()->GetWorldPose();
+             ignition::math::Pose3d position = this->pose->getModel()->WorldPose();
              
 
 
-             position.pos.x = Pose3DData->x / Pose3DData->h;
-             position.pos.y = Pose3DData->y / Pose3DData->h;
-             position.pos.z = Pose3DData->z / Pose3DData->h;
+             position.Pos()[0] = Pose3DData->x / Pose3DData->h;
+             position.Pos()[1] = Pose3DData->y / Pose3DData->h;
+             position.Pos()[2] = Pose3DData->z / Pose3DData->h;
 
-             position.rot.w = Pose3DData->q0;
-             position.rot.x = Pose3DData->q1;
-             position.rot.y = Pose3DData->q2;
-             position.rot.z = Pose3DData->q3;
+             position.Rot().W() = Pose3DData->q0;
+             position.Rot().X() = Pose3DData->q1;
+             position.Rot().Y() = Pose3DData->q2;
+             position.Rot().Z() = Pose3DData->q3;
 
              this->pose->getModel()->SetWorldPose(position);
 

--- a/src/drivers/gazebo/plugins/holo_car/holoCarPose3d.h
+++ b/src/drivers/gazebo/plugins/holo_car/holoCarPose3d.h
@@ -41,7 +41,7 @@ namespace gazebo {
             float q2;
             float q3;
         };
-        math::Quaternion initial_q;
+        ignition::math::Quaternion<double> initial_q;
         pose3d_t robotPose3D;
         std::string namePose3D;
         
@@ -49,7 +49,7 @@ namespace gazebo {
         
         void OnUpdate();
         physics::ModelPtr model;
-        math::Pose position;
+        ignition::math::Pose3d position;
         event::ConnectionPtr updateConnection;
         
         

--- a/src/drivers/gazebo/plugins/opel/opelMotors.cc
+++ b/src/drivers/gazebo/plugins/opel/opelMotors.cc
@@ -24,7 +24,7 @@ namespace gazebo
     {
         this->model = _model;
         this->node = transport::NodePtr(new transport::Node());
-        this->node->Init(this->model->GetWorld()->GetName());
+        this->node->Init(this->model->GetWorld()->Name());
 
         this->updateConnection = event::Events::ConnectWorldUpdateBegin(
                                     boost::bind(&Motors::OnUpdate, this));
@@ -63,14 +63,15 @@ namespace gazebo
 
         }
 
-        float z = model->GetRelativeLinearVel().z;
-        math::Vector3 vel(0,-robotMotors.v/10.0,0);
+        float z = model->RelativeLinearVel()[2];
+        ignition::math::Vector3d vel(0,-robotMotors.v/10.0,0);
 
-        math::Quaternion rot = model->GetWorldPose().rot;
-        vel = rot.GetAsMatrix3()*vel;
+        ignition::math::Quaternion<double> rot = model->WorldPose().Rot();
+        ignition::math::Matrix3d inter_mat(rot);
+        vel = inter_mat*vel;
 
         this->model->SetLinearVel(vel);
-        this->model->SetAngularVel(math::Vector3(0,0,robotMotors.w));
+        this->model->SetAngularVel(ignition::math::Vector3d(0,0,robotMotors.w));
 
     }
 

--- a/src/drivers/gazebo/plugins/opel/opelMotors.h
+++ b/src/drivers/gazebo/plugins/opel/opelMotors.h
@@ -1,6 +1,5 @@
 #include <boost/bind.hpp>
 #include <gazebo/gazebo.hh>
-#include <gazebo/math/Angle.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/transport/transport.hh>

--- a/src/drivers/gazebo/plugins/opel/pose3d.cc
+++ b/src/drivers/gazebo/plugins/opel/pose3d.cc
@@ -37,17 +37,17 @@ namespace gazebo {
             pthread_create(&thr_gui, NULL, &Pose3DICE, (void*) this);
         }
 
-        position = model->GetWorldPose();
-        this->initial_q = position.rot;
+        position = model->WorldPose();
+        this->initial_q = position.Rot();
 
 
         pthread_mutex_lock(&mutex);
-        robotPose3D.x = position.pos.x;
-        robotPose3D.y = position.pos.y;
-        robotPose3D.q0 = position.rot.w;
-        robotPose3D.q1 = position.rot.x;
-        robotPose3D.q2 = position.rot.y;
-        robotPose3D.q3 = position.rot.z;
+        robotPose3D.x = position.Pos()[0];
+        robotPose3D.y = position.Pos()[1];
+        robotPose3D.q0 = position.Rot().W();
+        robotPose3D.q1 = position.Rot().X();
+        robotPose3D.q2 = position.Rot().Y();
+        robotPose3D.q3 = position.Rot().Z();
         pthread_mutex_unlock(&mutex);
 
     }
@@ -64,18 +64,18 @@ namespace gazebo {
         
         virtual int setPose3DData(const jderobot::Pose3DDataPtr&  Pose3DData,
         						     const Ice::Current&) {
-             math::Pose position = this->pose->getModel()->GetWorldPose();
+             ignition::math::Pose3d position = this->pose->getModel()->WorldPose();
              
 
 
-             position.pos.x = Pose3DData->x / Pose3DData->h;
-             position.pos.y = Pose3DData->y / Pose3DData->h;
-             position.pos.z = Pose3DData->z / Pose3DData->h;
+             position.Pos()[0] = Pose3DData->x / Pose3DData->h;
+             position.Pos()[1] = Pose3DData->y / Pose3DData->h;
+             position.Pos()[2] = Pose3DData->z / Pose3DData->h;
 
-             position.rot.w = Pose3DData->q0;
-             position.rot.x = Pose3DData->q1;
-             position.rot.y = Pose3DData->q2;
-             position.rot.z = Pose3DData->q3;
+             position.Rot().W() = Pose3DData->q0;
+             position.Rot().X() = Pose3DData->q1;
+             position.Rot().Y() = Pose3DData->q2;
+             position.Rot().Z() = Pose3DData->q3;
 
              this->pose->getModel()->SetWorldPose(position);
 

--- a/src/drivers/gazebo/plugins/opel/pose3d.h
+++ b/src/drivers/gazebo/plugins/opel/pose3d.h
@@ -41,7 +41,7 @@ namespace gazebo {
             float q2;
             float q3;
         };
-        math::Quaternion initial_q;
+        ignition::math::Quaternion<double> initial_q;
         pose3d_t robotPose3D;
         std::string namePose3D;
         
@@ -49,7 +49,7 @@ namespace gazebo {
         
         void OnUpdate();
         physics::ModelPtr model;
-        math::Pose position;
+        ignition::math::Pose3d position;
         event::ConnectionPtr updateConnection;
         
         

--- a/src/drivers/gazebo/plugins/pibot/motors.cc
+++ b/src/drivers/gazebo/plugins/pibot/motors.cc
@@ -25,7 +25,7 @@ namespace gazebo
     {
         this->model = _model;
         this->node = transport::NodePtr(new transport::Node());
-        this->node->Init(this->model->GetWorld()->GetName());
+        this->node->Init(this->model->GetWorld()->Name());
 
         this->updateConnection = event::Events::ConnectWorldUpdateBegin(
                                     boost::bind(&Motors::OnUpdate, this));
@@ -65,7 +65,7 @@ namespace gazebo
 
         }
 
-        float z = model->GetRelativeLinearVel().z;
+        float z = model->RelativeLinearVel()[2];
         pthread_mutex_lock(&mutexMotor);
         if ((now - robotMotors.lastVtime) < 2){
             v = robotMotors.v;
@@ -74,13 +74,14 @@ namespace gazebo
             w = robotMotors.w;
         }
         pthread_mutex_unlock(&mutexMotor);
-        math::Vector3 vel(v,0,z);
+        ignition::math::Vector3d vel(v,0,z);
 
-        math::Quaternion rot = model->GetWorldPose().rot;
-        vel = rot.GetAsMatrix3()*vel;
+        ignition::math::Quaternion<double> rot = model->WorldPose().Rot();
+        ignition::math::Matrix3d inter_mat(rot);
+        vel = inter_mat*vel;
 
         this->model->SetLinearVel(vel);
-        this->model->SetAngularVel(math::Vector3(0,0,w));
+        this->model->SetAngularVel(ignition::math::Vector3d(0,0,w));
     }
 
     class MotorsI : virtual public jderobot::Motors {

--- a/src/drivers/gazebo/plugins/pibot/motors.h
+++ b/src/drivers/gazebo/plugins/pibot/motors.h
@@ -1,6 +1,5 @@
 #include <boost/bind.hpp>
 #include <gazebo/gazebo.hh>
-#include <gazebo/math/Angle.hh>
 #include <gazebo/physics/physics.hh>
 #include <gazebo/common/common.hh>
 #include <gazebo/transport/transport.hh>

--- a/src/drivers/gazebo/plugins/pibot/pose3d.cc
+++ b/src/drivers/gazebo/plugins/pibot/pose3d.cc
@@ -36,17 +36,17 @@ namespace gazebo {
             pthread_create(&thr_gui, NULL, &Pose3DICE, (void*) this);
         }
 
-        position = model->GetWorldPose();
-        this->initial_q = position.rot;
+        position = model->WorldPose();
+        this->initial_q = position.Rot();
 
 
         pthread_mutex_lock(&mutex);
-        robotPose3D.x = position.pos.x;
-        robotPose3D.y = position.pos.y;
-        robotPose3D.q0 = position.rot.w;
-        robotPose3D.q1 = position.rot.x;
-        robotPose3D.q2 = position.rot.y;
-        robotPose3D.q3 = position.rot.z;
+        robotPose3D.x = position.Pos()[0];
+        robotPose3D.y = position.Pos()[1];
+        robotPose3D.q0 = position.Rot().W();
+        robotPose3D.q1 = position.Rot().X();
+        robotPose3D.q2 = position.Rot().Y();
+        robotPose3D.q3 = position.Rot().Z();
         pthread_mutex_unlock(&mutex);
 
     }
@@ -63,18 +63,18 @@ namespace gazebo {
         
         virtual int setPose3DData(const jderobot::Pose3DDataPtr&  Pose3DData,
         						     const Ice::Current&) {
-             math::Pose position = this->pose->getModel()->GetWorldPose();
+             ignition::math::Pose3d position = this->pose->getModel()->WorldPose();
              
 
 
-             position.pos.x = Pose3DData->x / Pose3DData->h;
-             position.pos.y = Pose3DData->y / Pose3DData->h;
-             position.pos.z = Pose3DData->z / Pose3DData->h;
+             position.Pos()[0] = Pose3DData->x / Pose3DData->h;
+             position.Pos()[1] = Pose3DData->y / Pose3DData->h;
+             position.Pos()[2] = Pose3DData->z / Pose3DData->h;
 
-             position.rot.w = Pose3DData->q0;
-             position.rot.x = Pose3DData->q1;
-             position.rot.y = Pose3DData->q2;
-             position.rot.z = Pose3DData->q3;
+             position.Rot().W() = Pose3DData->q0;
+             position.Rot().X() = Pose3DData->q1;
+             position.Rot().Y() = Pose3DData->q2;
+             position.Rot().Z() = Pose3DData->q3;
 
              this->pose->getModel()->SetWorldPose(position);
 

--- a/src/drivers/gazebo/plugins/pibot/pose3d.h
+++ b/src/drivers/gazebo/plugins/pibot/pose3d.h
@@ -41,7 +41,7 @@ namespace gazebo {
             float q2;
             float q3;
         };
-        math::Quaternion initial_q;
+        ignition::math::Quaternion<double> initial_q;
         pose3d_t robotPose3D;
         std::string namePose3D;
         
@@ -49,7 +49,7 @@ namespace gazebo {
         
         void OnUpdate();
         physics::ModelPtr model;
-        math::Pose position;
+        ignition::math::Pose3d position;
         event::ConnectionPtr updateConnection;
         
         

--- a/src/drivers/gazebo/plugins/pioneer/motors.cc
+++ b/src/drivers/gazebo/plugins/pioneer/motors.cc
@@ -30,7 +30,7 @@ namespace gazebo {
         this->model = _model;
 
         this->node = transport::NodePtr(new transport::Node());
-        this->node->Init(this->model->GetWorld()->GetName());
+        this->node->Init(this->model->GetWorld()->Name());
 
         //this->velSub = this->node->Subscribe(std::string("~/") + this->model->GetName() + "/vel_cmd", &Motors::OnVelMsg, this);
         if (!_sdf->HasElement("left_joint"))
@@ -67,13 +67,13 @@ namespace gazebo {
     // Called by the world update start event
 
     void Motors::Init() {
-        this->wheelSeparation = this->leftJoint->GetAnchor(0).Distance(this->rightJoint->GetAnchor(0));
+        this->wheelSeparation = this->leftJoint->Anchor(0).Distance(this->rightJoint->Anchor(0));
         std::cout << "Wheel Separation:" << this->wheelSeparation << std::endl;
         physics::EntityPtr parent = boost::dynamic_pointer_cast<physics::Entity > (this->leftJoint->GetChild());
 
-        math::Box bb = parent->GetBoundingBox();
+        ignition::math::Box bb = parent->BoundingBox();
 
-        this->wheelRadius = bb.GetSize().GetMax() * 0.5;
+        this->wheelRadius = bb.Size().Max() * 0.5;
         std::cout << "Wheel Diameter:" << this->wheelRadius * 2 << std::endl;
     }
 

--- a/src/drivers/gazebo/plugins/pioneer/pose3d.cc
+++ b/src/drivers/gazebo/plugins/pioneer/pose3d.cc
@@ -37,17 +37,17 @@ namespace gazebo {
             pthread_create(&thr_gui, NULL, &Pose3DICE, (void*) this);
         }
 
-        position = model->GetWorldPose();
-        this->initial_q = position.rot;
+        position = model->WorldPose();
+        this->initial_q = position.Rot();
 
 
         pthread_mutex_lock(&mutex);
-        robotPose3D.x = position.pos.x;
-        robotPose3D.y = position.pos.y;
-        robotPose3D.q0 = position.rot.w;
-        robotPose3D.q1 = position.rot.x;
-        robotPose3D.q2 = position.rot.y;
-        robotPose3D.q3 = position.rot.z;
+        robotPose3D.x = position.Pos()[0];
+        robotPose3D.y = position.Pos()[1];
+        robotPose3D.q0 = position.Rot().W();
+        robotPose3D.q1 = position.Rot().X();
+        robotPose3D.q2 = position.Rot().Y();
+        robotPose3D.q3 = position.Rot().Z();
         pthread_mutex_unlock(&mutex);
 
     }
@@ -64,18 +64,18 @@ namespace gazebo {
         
         virtual int setPose3DData(const jderobot::Pose3DDataPtr&  Pose3DData,
         						     const Ice::Current&) {
-             math::Pose position = this->pose->getModel()->GetWorldPose();
+             ignition::math::Pose3d position = this->pose->getModel()->WorldPose();
              
 
 
-             position.pos.x = Pose3DData->x / Pose3DData->h;
-             position.pos.y = Pose3DData->y / Pose3DData->h;
-             position.pos.z = Pose3DData->z / Pose3DData->h;
+             position.Pos()[0] = Pose3DData->x / Pose3DData->h;
+             position.Pos()[1] = Pose3DData->y / Pose3DData->h;
+             position.Pos()[2] = Pose3DData->z / Pose3DData->h;
 
-             position.rot.w = Pose3DData->q0;
-             position.rot.x = Pose3DData->q1;
-             position.rot.y = Pose3DData->q2;
-             position.rot.z = Pose3DData->q3;
+             position.Rot().W() = Pose3DData->q0;
+             position.Rot().X() = Pose3DData->q1;
+             position.Rot().Y() = Pose3DData->q2;
+             position.Rot().Z() = Pose3DData->q3;
 
              this->pose->getModel()->SetWorldPose(position);
 

--- a/src/drivers/gazebo/plugins/pioneer/pose3d.h
+++ b/src/drivers/gazebo/plugins/pioneer/pose3d.h
@@ -41,7 +41,7 @@ namespace gazebo {
             float q2;
             float q3;
         };
-        math::Quaternion initial_q;
+        ignition::math::Quaternion<double> initial_q;
         pose3d_t robotPose3D;
         std::string namePose3D;
         
@@ -49,7 +49,7 @@ namespace gazebo {
         
         void OnUpdate();
         physics::ModelPtr model;
-        math::Pose position;
+        ignition::math::Pose3d position;
         event::ConnectionPtr updateConnection;
         
         

--- a/src/drivers/gazebo/plugins/pioneer/pose3dencoders.cc
+++ b/src/drivers/gazebo/plugins/pioneer/pose3dencoders.cc
@@ -95,7 +95,7 @@ namespace gazebo {
 
         //          ----------ENCODERS----------
         //GET pose3dencoders data from left_camera (PAN&TILT)
-        this->cameraLeft.encoder.pan = this->cameraLeft.camera_link_pan->GetRelativePose().rot.GetAsEuler().z * 180.0 / M_PI;
+        this->cameraLeft.encoder.pan = this->cameraLeft.camera_link_pan->RelativePose().Rot().Yaw() * 180.0 / M_PI;
         if (this->cameraLeft.encoder.pan > 0) {
             this->cameraLeft.encoder.pan = 180 - this->cameraLeft.encoder.pan;
         }
@@ -104,13 +104,13 @@ namespace gazebo {
         }
 
         //std::cout << this->cameraLeft.encoder.pan << std::endl;
-        this->cameraLeft.encoder.tilt = this->cameraLeft.camera_link_tilt->GetRelativePose().rot.GetAsEuler().y * 180.0 / M_PI;
+        this->cameraLeft.encoder.tilt = this->cameraLeft.camera_link_tilt->RelativePose().Rot().Yaw() * 180.0 / M_PI;
         //std::cout << this->cameraLeft.encoder.tilt << std::endl;
 
 
         //GET pose3dencoders data from left_camera (PAN&TILT)
 
-        this->cameraRight.encoder.pan = this->cameraRight.camera_link_pan->GetRelativePose().rot.GetAsEuler().z * 180.0 / M_PI;
+        this->cameraRight.encoder.pan = this->cameraRight.camera_link_pan->RelativePose().Rot().Yaw() * 180.0 / M_PI;
         if (this->cameraRight.encoder.pan > 0) {
             this->cameraRight.encoder.pan = 180 - this->cameraRight.encoder.pan;
         }
@@ -119,7 +119,7 @@ namespace gazebo {
         }
 
         //std::cout << this->cameraRight.pan << std::endl;
-        this->cameraRight.encoder.tilt = this->cameraRight.camera_link_tilt->GetRelativePose().rot.GetAsEuler().y * 180.0 / M_PI;
+        this->cameraRight.encoder.tilt = this->cameraRight.camera_link_tilt->RelativePose().Rot().Yaw() * 180.0 / M_PI;
         //std::cout << this->cameraRight.encoder.tilt << std::endl;
 
         // double setPanRight = -50;

--- a/src/drivers/gazebo/plugins/quadrotor/CMakeLists.txt
+++ b/src/drivers/gazebo/plugins/quadrotor/CMakeLists.txt
@@ -66,7 +66,7 @@ set_target_properties(quadrotorplugin2 PROPERTIES COMPILE_FLAGS "${GAZEBO_CXX_FL
 # Ice
 target_link_libraries(quadrotorplugin2
 	Ice
-	IceUtil
+	# IceUtil
 	JderobotInterfaces
 	${ZeroCIce_LIBRARIES}
 	${easyiceconfig_LIBRARIES}

--- a/src/drivers/gazebo/plugins/quadrotor/include/quadrotor/control/twist.hh
+++ b/src/drivers/gazebo/plugins/quadrotor/include/quadrotor/control/twist.hh
@@ -21,14 +21,14 @@
 #ifndef TWIST_HH
 #define TWIST_HH
 
-#include <gazebo/math/Vector3.hh>
+#include <ignition/math/Vector3.hh>
 
-namespace gazebo{
+namespace ignition{
 namespace math{
 
 typedef struct Twist_{
-    gazebo::math::Vector3 linear;
-    gazebo::math::Vector3 angular;
+    ignition::math::Vector3d linear;
+    ignition::math::Vector3d angular;
 }Twist;
 
 }}//NS

--- a/src/drivers/gazebo/plugins/quadrotor/include/quadrotor/quadrotorcontrol.hh
+++ b/src/drivers/gazebo/plugins/quadrotor/include/quadrotor/quadrotorcontrol.hh
@@ -45,8 +45,8 @@ public:
 public:
     void takeoff();
     void land();
-    void setTargetVelocity(gazebo::math::Twist twist);
-    void teleport(gazebo::math::Pose pose);
+    void setTargetVelocity(ignition::math::Twist twist);
+    void teleport(ignition::math::Pose3d pose);
 
     std::string _log_prefix;
 
@@ -60,7 +60,7 @@ protected:
     QuadrotorState my_state;
     Controllers controllers;
     gazebo::common::Time last_simTime;
-    gazebo::math::Twist velocity_command;
+    ignition::math::Twist velocity_command;
 
     std::pair<double,double> fly_state_thresholds;
     double takeoff_speed;

--- a/src/drivers/gazebo/plugins/quadrotor/include/quadrotor/quadrotorplugin.hh
+++ b/src/drivers/gazebo/plugins/quadrotor/include/quadrotor/quadrotorplugin.hh
@@ -24,7 +24,7 @@
 
 #include <gazebo/gazebo.hh>
 #include <gazebo/common/common.hh>
-#include <gazebo/math/Pose.hh>
+#include <ignition/math/Pose3.hh>
 
 #include <quadrotor/quadrotorsensors.hh>
 #include <quadrotor/quadrotorcontrol.hh>

--- a/src/drivers/gazebo/plugins/quadrotor/include/quadrotor/quadrotorsensors.hh
+++ b/src/drivers/gazebo/plugins/quadrotor/include/quadrotor/quadrotorsensors.hh
@@ -84,7 +84,7 @@ private:
 
 public:
     cv::Mat img[NUM_CAMS];
-    gazebo::math::Pose pose;
+    ignition::math::Pose3d pose;
     double altitude;
 
 };

--- a/src/drivers/gazebo/plugins/quadrotor/src/cameraproxy.cc
+++ b/src/drivers/gazebo/plugins/quadrotor/src/cameraproxy.cc
@@ -49,7 +49,7 @@ CameraProxy::setActive(int id){
     /// deactivate previous
     if (active_camera != -1){
         cameras[active_camera]->SetActive(false);
-        cameras[active_camera]->DisconnectUpdated(active_sub);
+        // cameras[active_camera]->DisconnectUpdated(active_sub);
     }
 
     /// active new
@@ -78,7 +78,7 @@ void
 CameraProxy::_on_cam_bootstrap(){
     lock.lock();
 
-    cameras[active_camera]->DisconnectUpdated(active_sub);
+    // cameras[active_camera]->DisconnectUpdated(active_sub);
 
     img = _createImageWrapper(cameras[active_camera], active_camera);
 

--- a/src/drivers/gazebo/plugins/quadrotor/src/interfaces/camerai.cpp
+++ b/src/drivers/gazebo/plugins/quadrotor/src/interfaces/camerai.cpp
@@ -41,7 +41,7 @@ CameraI::onCameraSensorBoostrap(){
 
     std::cout<<"CameraI::onCameraSensorBoostrap()"<<std::endl;
 
-    sensor->cam[cam_id]->DisconnectUpdated(cameraSensorConnection);
+    // sensor->cam[cam_id]->DisconnectUpdated(cameraSensorConnection);
 
     imgCached = sensor->img[cam_id].clone();
 

--- a/src/drivers/gazebo/plugins/quadrotor/src/interfaces/cmdveli.cpp
+++ b/src/drivers/gazebo/plugins/quadrotor/src/interfaces/cmdveli.cpp
@@ -19,11 +19,11 @@
 
 
 #include "quadrotor/interfaces/cmdveli.h"
-
+// #include "quadrotor/control/twist.hh"
 
 using namespace quadrotor::interfaces;
 using namespace jderobot;
-using namespace gazebo::math;
+using namespace ignition::math;
 
 CMDVelI::CMDVelI (QuadrotorControl *control):
     control(control)
@@ -36,8 +36,8 @@ CMDVelI::~CMDVelI ()
 Ice::Int
 CMDVelI::setCMDVelData(const jderobot::CMDVelDataPtr& data, const Ice::Current&){
 	Twist twist_cmd;
-	twist_cmd.linear = Vector3(data->linearX, data->linearY, data->linearZ);
-	twist_cmd.angular = Vector3(data->angularX, data->angularY, data->angularZ);
+	twist_cmd.linear = Vector3d(data->linearX, data->linearY, data->linearZ);
+	twist_cmd.angular = Vector3d(data->angularX, data->angularY, data->angularZ);
 
 	control->setTargetVelocity(twist_cmd);
 

--- a/src/drivers/gazebo/plugins/quadrotor/src/interfaces/pose3di.cpp
+++ b/src/drivers/gazebo/plugins/quadrotor/src/interfaces/pose3di.cpp
@@ -36,24 +36,24 @@ Pose3DI::~Pose3DI ()
 
 Pose3DDataPtr
 Pose3DI::getPose3DData ( const Ice::Current& ){
-    gazebo::math::Pose pose = sensor->pose;
+    ignition::math::Pose3d pose = sensor->pose;
 
-    data->x = pose.pos.x;
-    data->y = pose.pos.y;
-    data->z = pose.pos.z;
+    data->x = pose.Pos()[0];
+    data->y = pose.Pos()[1];
+    data->z = pose.Pos()[2];
     data->h = 1;
-    data->q0 = pose.rot.w;
-    data->q1 = pose.rot.x;
-    data->q2 = pose.rot.y;
-    data->q3 = pose.rot.z;
+    data->q0 = pose.Rot().W();
+    data->q1 = pose.Rot().X();
+    data->q2 = pose.Rot().Y();
+    data->q3 = pose.Rot().Z();
 
     return data;
 }
 
 Ice::Int
 Pose3DI::setPose3DData ( const jderobot::Pose3DDataPtr & data, const Ice::Current& ){
-    gazebo::math::Pose pose(gazebo::math::Vector3(data->x, data->y, data->z),
-                            gazebo::math::Quaternion(data->q0, data->q1, data->q2, data->q3));
+    ignition::math::Pose3d pose(ignition::math::Vector3d(data->x, data->y, data->z),
+                            ignition::math::Quaternion<double>(data->q0, data->q1, data->q2, data->q3));
     control->teleport(pose);
     return 0;
 }

--- a/src/drivers/gazebo/plugins/quadrotor/src/quadrotorcontrol.cc
+++ b/src/drivers/gazebo/plugins/quadrotor/src/quadrotorcontrol.cc
@@ -25,7 +25,7 @@ const std::string quadrotor::QuadrotorStateDescription[] = {"Unknown", "Flying",
 
 
 using namespace quadrotor;
-using namespace gazebo::math;
+using namespace ignition::math;
 using namespace gazebo::physics;
 using namespace gazebo::common;
 
@@ -45,7 +45,7 @@ void
 QuadrotorControl::Load(LinkPtr _base_link, sdf::ElementPtr _sdf){
     base_link = _base_link;
     inertial = _base_link->GetInertial();
-    mass = inertial->GetMass();
+    mass = inertial->Mass();
 
     fly_state_thresholds.first = sdf2value<double>(_sdf, "landCompletedAt", 0.2);
     fly_state_thresholds.second = sdf2value<double>(_sdf, "takeoffCompletedAt", 1.5);
@@ -101,7 +101,7 @@ QuadrotorControl::setTargetVelocity(Twist twist){
 }
 
 void
-QuadrotorControl::teleport(gazebo::math::Pose pose){
+QuadrotorControl::teleport(ignition::math::Pose3d pose){
     base_link->GetModel()->SetWorldPose(pose);
 }
 
@@ -151,15 +151,15 @@ QuadrotorControl::_control_loop_novel(const gazebo::common::UpdateInfo & /*_info
     /// quadrotor will fall.
 
     // getting gravity dynamically to allow on-demand changes.
-    Vector3 gravity = base_link->GetWorld()->GetPhysicsEngine()->GetGravity();
-    Vector3 counter_gravity = mass*-gravity;
+    ignition::math::Vector3d gravity = base_link->GetWorld()->Gravity();
+    ignition::math::Vector3d counter_gravity = mass*-gravity;
     //base_link->AddForce(counter_gravity);
 
-    Pose pose = base_link->GetWorldPose();
+    ignition::math::Pose3d pose = base_link->WorldPose();
 
-    Vector3 vel_model = base_link->GetRelativeLinearVel();
-    Vector3 vel_world = base_link->GetWorldLinearVel(); //pose.rot.RotateVectorReverse(vel_model);
-    Vector3 up_down_vel = Vector3(0,0,0.001);
+    ignition::math::Vector3d vel_model = base_link->RelativeLinearVel();
+    ignition::math::Vector3d vel_world = base_link->WorldLinearVel(); //pose.rot.RotateVectorReverse(vel_model);
+    ignition::math::Vector3d up_down_vel(0,0,0.001);
 
 
     switch(my_state){

--- a/src/drivers/gazebo/plugins/quadrotor/src/quadrotorcontrol_hector.cc
+++ b/src/drivers/gazebo/plugins/quadrotor/src/quadrotorcontrol_hector.cc
@@ -45,7 +45,7 @@
 #define VELOCITY_BASED_TAKEOFF
 
 using namespace quadrotor;
-using namespace gazebo::math;
+using namespace ignition::math;
 using namespace gazebo::physics;
 using namespace gazebo::common;
 
@@ -60,45 +60,45 @@ QuadrotorControl::_control_loop_hector(const gazebo::common::UpdateInfo & _info)
     //double max_force_ = mass*10/dt;
 
     // Get kinematics
-    Pose pose = base_link->GetWorldPose();
-    Vector3 euler = pose.rot.GetAsEuler();
-    Vector3 linear_velocity = base_link->GetWorldLinearVel();
-    Vector3 angular_velocity = base_link->GetWorldAngularVel();
-    Vector3 acceleration = base_link->GetWorldLinearAccel();
-    Vector3 inertia = inertia = inertial->GetPrincipalMoments();
+    ignition::math::Pose3d pose = base_link->WorldPose();
+    ignition::math::Vector3d euler = pose.Rot().Euler();
+    ignition::math::Vector3d linear_velocity = base_link->WorldLinearVel();
+    ignition::math::Vector3d angular_velocity = base_link->WorldAngularVel();
+    ignition::math::Vector3d acceleration = base_link->WorldLinearAccel();
+    ignition::math::Vector3d inertia = inertia = inertial->PrincipalMoments();
 
-    double velocity_command_linear_z = velocity_command.linear.z;
+    double velocity_command_linear_z = velocity_command.linear[2];
 #ifdef VELOCITY_BASED_TAKEOFF
     // Inject landing/takingoff
     if (my_state == QuadrotorState::Landing)
-        velocity_command_linear_z = std::min(velocity_command.linear.z, -land_speed);
+        velocity_command_linear_z = std::min(velocity_command.linear[2], -land_speed);
     if (my_state == QuadrotorState::TakingOff)
-        velocity_command_linear_z = std::max(velocity_command.linear.z, +takeoff_speed);
+        velocity_command_linear_z = std::max(velocity_command.linear[2], +takeoff_speed);
 #endif
 
     // Get gravity
-    Vector3 gravity = base_link->GetWorld()->GetPhysicsEngine()->GetGravity();
-    Vector3 gravity_body = pose.rot.RotateVector(gravity);
-    double gravity_module = gravity_body.GetLength();
+    ignition::math::Vector3d gravity = base_link->GetWorld()->Gravity();
+    ignition::math::Vector3d gravity_body = pose.Rot().RotateVector(gravity);
+    double gravity_module = gravity_body.Length();
     double load_factor = gravity_module * gravity_module / gravity.Dot(gravity_body);  // Get gravity
 
     // Rotate vectors to coordinate frames relevant for control
-    Quaternion heading_quaternion(cos(euler.z/2),0,0,sin(euler.z/2));
-    Vector3 velocity_xy = heading_quaternion.RotateVectorReverse(linear_velocity);
-    Vector3 acceleration_xy = heading_quaternion.RotateVectorReverse(acceleration);
-    Vector3 angular_velocity_body = pose.rot.RotateVectorReverse(angular_velocity);
+    ignition::math::Quaternion<double> heading_quaternion(cos(euler[2]/2),0,0,sin(euler[2]/2));
+    ignition::math::Vector3d velocity_xy = heading_quaternion.RotateVectorReverse(linear_velocity);
+    ignition::math::Vector3d acceleration_xy = heading_quaternion.RotateVectorReverse(acceleration);
+    ignition::math::Vector3d angular_velocity_body = pose.Rot().RotateVectorReverse(angular_velocity);
 
     // update controllers
-    Vector3 force(Vector3::Zero), torque(Vector3::Zero);
+    ignition::math::Vector3d force(ignition::math::Vector3d::Zero), torque(ignition::math::Vector3d::Zero);
 
-    double pitch_command =  controllers.velocity_x.update(velocity_command.linear.x, velocity_xy.x, acceleration_xy.x, dt) / gravity_module;
-    double roll_command  = -controllers.velocity_y.update(velocity_command.linear.y, velocity_xy.y, acceleration_xy.y, dt) / gravity_module;
-    torque.x = inertia.x *  controllers.roll.update(roll_command, euler.x, angular_velocity_body.x, dt);
-    torque.y = inertia.y *  controllers.pitch.update(pitch_command, euler.y, angular_velocity_body.y, dt);
-    torque.z = inertia.z *  controllers.yaw.update(velocity_command.angular.z, angular_velocity.z, 0, dt);
-    force.z  = mass      * (controllers.velocity_z.update(velocity_command_linear_z,  linear_velocity.z, acceleration.z, dt) + load_factor * gravity_module);
+    double pitch_command =  controllers.velocity_x.update(velocity_command.linear[0], velocity_xy[0], acceleration_xy[0], dt) / gravity_module;
+    double roll_command  = -controllers.velocity_y.update(velocity_command.linear[1], velocity_xy[1], acceleration_xy[1], dt) / gravity_module;
+    torque[0] = inertia[0] *  controllers.roll.update(roll_command, euler[0], angular_velocity_body[0], dt);
+    torque[1] = inertia[1] *  controllers.pitch.update(pitch_command, euler[1], angular_velocity_body[1], dt);
+    torque[2] = inertia[2] *  controllers.yaw.update(velocity_command.angular[2], angular_velocity[2], 0, dt);
+    force[2]  = mass      * (controllers.velocity_z.update(velocity_command_linear_z,  linear_velocity[2], acceleration[2], dt) + load_factor * gravity_module);
     //if (max_force_ > 0.0 && force.z > max_force_) force.z = max_force_;
-    if (force.z < 0.0) force.z = 0.0;
+    if (force[2] < 0.0) force[2] = 0.0;
 
     if (my_state != QuadrotorState::Landed){
         base_link->AddRelativeForce(force);

--- a/src/drivers/gazebo/plugins/quadrotor/src/quadrotorplugin.cc
+++ b/src/drivers/gazebo/plugins/quadrotor/src/quadrotorplugin.cc
@@ -25,7 +25,7 @@ GZ_REGISTER_MODEL_PLUGIN(quadrotor::QuadrotorPlugin)
 
 using namespace quadrotor;
 using namespace gazebo::physics;
-using namespace gazebo::math;
+using namespace ignition::math;
 using namespace gazebo::event;
 using namespace gazebo::common;
 

--- a/src/drivers/gazebo/plugins/quadrotor/src/quadrotorsensors.cc
+++ b/src/drivers/gazebo/plugins/quadrotor/src/quadrotorsensors.cc
@@ -60,7 +60,7 @@ QuadRotorSensors::Load(ModelPtr model){
     }
 
     // weak-fix for sonar value at boostrap (1/2)
-    altitude = model->GetWorldPose().pos.z;
+    altitude = model->WorldPose().Pos()[2];
 }
 
 
@@ -123,7 +123,7 @@ QuadRotorSensors::_on_cam(int id){
         uint32_t w = cam[id]->ImageWidth();
         img[id] = cv::Mat(h, w, CV_8UC3, (uint8_t*)data);
 
-        cam[id]->DisconnectUpdated(sub_cam[id]); // close connection
+        // cam[id]->DisconnectUpdated(sub_cam[id]); // close connection
     }
 }
 
@@ -146,7 +146,7 @@ QuadRotorSensors::_on_sonar(){
 
 void
 QuadRotorSensors::_on_imu(){
-    pose = model->GetWorldPose();
-    pose.rot = imu->Orientation();
+    pose = model->WorldPose();
+    pose.Rot() = imu->Orientation();
 //    std::cout<<pose<<std::endl;
 }

--- a/src/drivers/gazebo/plugins/roomba/CMakeLists.txt
+++ b/src/drivers/gazebo/plugins/roomba/CMakeLists.txt
@@ -36,7 +36,7 @@ set_target_properties(roombaplugin PROPERTIES COMPILE_FLAGS "${GAZEBO_CXX_FLAGS}
 # Ice
 target_link_libraries(roombaplugin
         Ice
-        IceUtil
+        # IceUtil
         JderobotInterfaces
         ${ZeroCIce_LIBRARIES}
         ${easyiceconfig_LIBRARIES}

--- a/src/drivers/gazebo/plugins/roomba/include/roomba/roombacontrol.hh
+++ b/src/drivers/gazebo/plugins/roomba/include/roomba/roombacontrol.hh
@@ -60,7 +60,7 @@ public:
     void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr _sdf);
     void Init(RoombaSensors* sensors);
     void OnUpdate(const gazebo::common::UpdateInfo & _info);
-    void teleport(gazebo::math::Pose pose);
+    void teleport(ignition::math::Pose3d pose);
 
 private:
     gazebo::event::ConnectionPtr updateConnection;

--- a/src/drivers/gazebo/plugins/roomba/include/roomba/roombaplugin.hh
+++ b/src/drivers/gazebo/plugins/roomba/include/roomba/roombaplugin.hh
@@ -24,7 +24,7 @@
 
 #include <gazebo/gazebo.hh>
 #include <gazebo/common/common.hh>
-#include <gazebo/math/Pose.hh>
+#include <ignition/math/Pose3.hh>
 
 #include <roomba/roombasensors.hh>
 #include <roomba/roombacontrol.hh>

--- a/src/drivers/gazebo/plugins/roomba/include/roomba/roombasensors.hh
+++ b/src/drivers/gazebo/plugins/roomba/include/roomba/roombasensors.hh
@@ -90,7 +90,7 @@ private:
 public:
     LaserD laserData;
     BumperD bumperData;
-    gazebo::math::Pose pose;
+    ignition::math::Pose3d pose;
 
     double position;
 };

--- a/src/drivers/gazebo/plugins/roomba/src/interfaces/pose3di.cpp
+++ b/src/drivers/gazebo/plugins/roomba/src/interfaces/pose3di.cpp
@@ -34,24 +34,24 @@ Pose3DI::~Pose3DI ()
 
 Pose3DDataPtr
 Pose3DI::getPose3DData ( const Ice::Current& ){
-    gazebo::math::Pose pose = sensor->pose;
+    ignition::math::Pose3d pose = sensor->pose;
 
-    data->x = pose.pos.x;
-    data->y = pose.pos.y;
-    data->z = pose.pos.z;
+    data->x = pose.Pos()[0];
+    data->y = pose.Pos()[1];
+    data->z = pose.Pos()[2];
     data->h = 1;
-    data->q0 = pose.rot.w;
-    data->q1 = pose.rot.x;
-    data->q2 = pose.rot.y;
-    data->q3 = pose.rot.z;
+    data->q0 = pose.Rot().W();
+    data->q1 = pose.Rot().X();
+    data->q2 = pose.Rot().Y();
+    data->q3 = pose.Rot().Z();
 
     return data;
 }
 
 Ice::Int
 Pose3DI::setPose3DData ( const jderobot::Pose3DDataPtr & data, const Ice::Current& ){
-    gazebo::math::Pose pose(gazebo::math::Vector3(data->x, data->y, data->z),
-                            gazebo::math::Quaternion(data->q0, data->q1, data->q2, data->q3));
+    ignition::math::Pose3d pose(ignition::math::Vector3d(data->x, data->y, data->z),
+                            ignition::math::Quaternion<double>(data->q0, data->q1, data->q2, data->q3));
     control->teleport(pose);
     return 0;
 }

--- a/src/drivers/gazebo/plugins/roomba/src/roombacontrol.cc
+++ b/src/drivers/gazebo/plugins/roomba/src/roombacontrol.cc
@@ -22,7 +22,7 @@
 #include "roomba/roombacontrol.hh"
 
 using namespace roomba;
-using namespace gazebo::math;
+using namespace ignition::math;
 using namespace gazebo::physics;
 using namespace gazebo::common;
 using namespace gazebo::transport;
@@ -44,7 +44,7 @@ RoombaControl::Load(ModelPtr model, sdf::ElementPtr _sdf){
     this->model = model;
 
     this->node = NodePtr(new Node());
-    this->node->Init(this->model->GetWorld()->GetName());
+    this->node->Init(this->model->GetWorld()->Name());
 
     //this->velSub = this->node->Subscribe(std::string("~/") + this->model->GetName() + "/vel_cmd", &Motors::OnVelMsg, this);
     if (!_sdf->HasElement("left_joint"))
@@ -75,12 +75,12 @@ void
 RoombaControl::Init(RoombaSensors *sensors){
     this->sensors = sensors;
 
-    this->wheelSeparation = this->leftJoint->GetAnchor(0).Distance(this->rightJoint->GetAnchor(0));
+    this->wheelSeparation = this->leftJoint->Anchor(0).Distance(this->rightJoint->Anchor(0));
     EntityPtr parent = boost::dynamic_pointer_cast<Entity > (this->leftJoint->GetChild());
 
-    Box bb = parent->GetBoundingBox();
+    Box bb = parent->BoundingBox();
 
-    this->wheelRadius = bb.GetSize().GetMax() * 0.5;
+    this->wheelRadius = bb.Size().Max() * 0.5;
 
     updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(
         boost::bind(&RoombaControl::OnUpdate, this, _1));
@@ -111,6 +111,6 @@ RoombaControl::OnUpdate(const gazebo::common::UpdateInfo & /*_info*/){
 }
 
 void
-RoombaControl::teleport(gazebo::math::Pose pose){
+RoombaControl::teleport(ignition::math::Pose3d pose){
     this->model->SetWorldPose(pose);
 }

--- a/src/drivers/gazebo/plugins/roomba/src/roombaplugin.cc
+++ b/src/drivers/gazebo/plugins/roomba/src/roombaplugin.cc
@@ -25,7 +25,7 @@ GZ_REGISTER_MODEL_PLUGIN(roomba::RoombaPlugin)
 
 using namespace roomba;
 using namespace gazebo::physics;
-using namespace gazebo::math;
+using namespace ignition::math;
 using namespace gazebo::event;
 using namespace gazebo::common;
 

--- a/src/drivers/gazebo/plugins/roomba/src/roombasensors.cc
+++ b/src/drivers/gazebo/plugins/roomba/src/roombasensors.cc
@@ -50,7 +50,7 @@ RoombaSensors::Load(ModelPtr model){
             bumper = std::static_pointer_cast<ContactSensor>(s);
         }
 
-        pose = model->GetWorldPose();
+        pose = model->WorldPose();
     }
 }
 
@@ -72,7 +72,7 @@ RoombaSensors::Init(){
     }else
         std::cerr << _log_prefix << "\t bumper was not connected (NULL pointer)" << std::endl;
 
-    ONDEBUG_INFO(std::cout << _log_prefix << "Initial Pose [x,y,z] " << pose.pos.x << ", " << pose.pos.y << ", " << pose.pos.z << std::endl;)
+    ONDEBUG_INFO(std::cout << _log_prefix << "Initial Pose [x,y,z] " << pose.Pos()[0] << ", " << pose.Pos()[1] << ", " << pose.Pos()[2] << std::endl;)
 
     //Pose3d
     updatePose = gazebo::event::Events::ConnectWorldUpdateBegin(
@@ -136,5 +136,5 @@ RoombaSensors::_on_bumper(){
 
 void
 RoombaSensors::OnUpdate(const gazebo::common::UpdateInfo & /*_info*/){
-    pose = model->GetWorldPose();
+    pose = model->WorldPose();
 }

--- a/src/drivers/gazebo/plugins/turtlebot/CMakeLists.txt
+++ b/src/drivers/gazebo/plugins/turtlebot/CMakeLists.txt
@@ -42,7 +42,7 @@ set_target_properties(turtlebotplugin PROPERTIES COMPILE_FLAGS "${GAZEBO_CXX_FLA
 # Ice
 target_link_libraries(turtlebotplugin
         Ice
-        IceUtil
+        # IceUtil
         JderobotInterfaces
         ${ZeroCIce_LIBRARIES}
         ${easyiceconfig_LIBRARIES}

--- a/src/drivers/gazebo/plugins/turtlebot/include/turtlebot/turtlebotcontrol.hh
+++ b/src/drivers/gazebo/plugins/turtlebot/include/turtlebot/turtlebotcontrol.hh
@@ -64,7 +64,7 @@ public:
     void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr _sdf);
     void Init(TurtlebotSensors* sensors);
     void OnUpdate(const gazebo::common::UpdateInfo & _info);
-    void teleport(gazebo::math::Pose pose);
+    void teleport(ignition::math::Pose3d pose);
 
 private:
     gazebo::event::ConnectionPtr updateConnection;

--- a/src/drivers/gazebo/plugins/turtlebot/include/turtlebot/turtlebotplugin.hh
+++ b/src/drivers/gazebo/plugins/turtlebot/include/turtlebot/turtlebotplugin.hh
@@ -28,7 +28,7 @@
 
 #include <gazebo/gazebo.hh>
 #include <gazebo/common/common.hh>
-#include <gazebo/math/Pose.hh>
+#include <ignition/math/Pose3.hh>
 
 #include <turtlebot/turtlebotsensors.hh>
 #include <turtlebot/turtlebotcontrol.hh>

--- a/src/drivers/gazebo/plugins/turtlebot/include/turtlebot/turtlebotsensors.hh
+++ b/src/drivers/gazebo/plugins/turtlebot/include/turtlebot/turtlebotsensors.hh
@@ -104,7 +104,7 @@ public:
     cv::Mat img[NUM_CAMS];
     LaserD laserData;
     BumperD bumperData;
-    gazebo::math::Pose pose;
+    ignition::math::Pose3d pose;
 
     double position;
 };

--- a/src/drivers/gazebo/plugins/turtlebot/src/interfaces/camerai.cpp
+++ b/src/drivers/gazebo/plugins/turtlebot/src/interfaces/camerai.cpp
@@ -46,7 +46,7 @@ CameraI::onCameraSensorBoostrap(){
 
     std::cout<<"CameraI::onCameraSensorBoostrap()"<<std::endl;
 
-    sensor->cam[cam_id]->DisconnectUpdated(cameraSensorConnection);
+    // sensor->cam[cam_id]->DisconnectUpdated(cameraSensorConnection);
 
     imgCached = sensor->img[cam_id].clone();
 

--- a/src/drivers/gazebo/plugins/turtlebot/src/interfaces/pose3di.cpp
+++ b/src/drivers/gazebo/plugins/turtlebot/src/interfaces/pose3di.cpp
@@ -35,24 +35,24 @@ Pose3DI::~Pose3DI ()
 
 Pose3DDataPtr
 Pose3DI::getPose3DData ( const Ice::Current& ){
-    gazebo::math::Pose pose = sensor->pose;
+    ignition::math::Pose3d pose = sensor->pose;
 
-    data->x = pose.pos.x;
-    data->y = pose.pos.y;
-    data->z = pose.pos.z;
+    data->x = pose.Pos()[0];
+    data->y = pose.Pos()[1];
+    data->z = pose.Pos()[2];
     data->h = 1;
-    data->q0 = pose.rot.w;
-    data->q1 = pose.rot.x;
-    data->q2 = pose.rot.y;
-    data->q3 = pose.rot.z;
+    data->q0 = pose.Rot().W();
+    data->q1 = pose.Rot().X();
+    data->q2 = pose.Rot().Y();
+    data->q3 = pose.Rot().Z();
 
     return data;
 }
 
 Ice::Int
 Pose3DI::setPose3DData ( const jderobot::Pose3DDataPtr & data, const Ice::Current& ){
-    gazebo::math::Pose pose(gazebo::math::Vector3(data->x, data->y, data->z),
-                            gazebo::math::Quaternion(data->q0, data->q1, data->q2, data->q3));
+    ignition::math::Pose3d pose(ignition::math::Vector3d(data->x, data->y, data->z),
+                            ignition::math::Quaternion<double>(data->q0, data->q1, data->q2, data->q3));
     control->teleport(pose);
     return 0;
 }

--- a/src/drivers/gazebo/plugins/turtlebot/src/turtlebotcontrol.cc
+++ b/src/drivers/gazebo/plugins/turtlebot/src/turtlebotcontrol.cc
@@ -26,7 +26,7 @@
 #include "turtlebot/turtlebotcontrol.hh"
 
 using namespace turtlebot;
-using namespace gazebo::math;
+using namespace ignition::math;
 using namespace gazebo::physics;
 using namespace gazebo::common;
 using namespace gazebo::transport;
@@ -48,7 +48,7 @@ TurtlebotControl::Load(ModelPtr model, sdf::ElementPtr _sdf){
     this->model = model;
 
     this->node = NodePtr(new Node());
-    this->node->Init(this->model->GetWorld()->GetName());
+    this->node->Init(this->model->GetWorld()->Name());
 
     //this->velSub = this->node->Subscribe(std::string("~/") + this->model->GetName() + "/vel_cmd", &Motors::OnVelMsg, this);
     if (!_sdf->HasElement("left_joint"))
@@ -79,12 +79,12 @@ void
 TurtlebotControl::Init(TurtlebotSensors *sensors){
     this->sensors = sensors;
 
-    this->wheelSeparation = this->leftJoint->GetAnchor(0).Distance(this->rightJoint->GetAnchor(0));
+    this->wheelSeparation = this->leftJoint->Anchor(0).Distance(this->rightJoint->Anchor(0));
     EntityPtr parent = boost::dynamic_pointer_cast<Entity > (this->leftJoint->GetChild());
 
-    Box bb = parent->GetBoundingBox();
+    Box bb = parent->BoundingBox();
 
-    this->wheelRadius = bb.GetSize().GetMax() * 0.5;
+    this->wheelRadius = bb.Size().Max() * 0.5;
 
     updateConnection = gazebo::event::Events::ConnectWorldUpdateBegin(
         boost::bind(&TurtlebotControl::OnUpdate, this, _1));
@@ -115,6 +115,6 @@ TurtlebotControl::OnUpdate(const gazebo::common::UpdateInfo & /*_info*/){
 }
 
 void
-TurtlebotControl::teleport(gazebo::math::Pose pose){
+TurtlebotControl::teleport(ignition::math::Pose3d pose){
     this->model->SetWorldPose(pose);
 }

--- a/src/drivers/gazebo/plugins/turtlebot/src/turtlebotplugin.cc
+++ b/src/drivers/gazebo/plugins/turtlebot/src/turtlebotplugin.cc
@@ -29,7 +29,7 @@ GZ_REGISTER_MODEL_PLUGIN(turtlebot::TurtlebotPlugin)
 
 using namespace turtlebot;
 using namespace gazebo::physics;
-using namespace gazebo::math;
+using namespace ignition::math;
 using namespace gazebo::event;
 using namespace gazebo::common;
 

--- a/src/drivers/gazebo/plugins/turtlebot/src/turtlebotsensors.cc
+++ b/src/drivers/gazebo/plugins/turtlebot/src/turtlebotsensors.cc
@@ -58,7 +58,7 @@ TurtlebotSensors::Load(ModelPtr model){
             bumper = std::static_pointer_cast<ContactSensor>(s);
         }
 
-        pose = model->GetWorldPose();
+        pose = model->WorldPose();
     }
 }
 
@@ -87,7 +87,7 @@ TurtlebotSensors::Init(){
     }else
         std::cerr << _log_prefix << "\t bumper was not connected (NULL pointer)" << std::endl;
 
-    ONDEBUG_INFO(std::cout << _log_prefix << "Initial Pose [x,y,z] " << pose.pos.x << ", " << pose.pos.y << ", " << pose.pos.z << std::endl;)
+    ONDEBUG_INFO(std::cout << _log_prefix << "Initial Pose [x,y,z] " << pose.Pos()[0] << ", " << pose.Pos()[1] << ", " << pose.Pos()[2] << std::endl;)
 
     //Pose3d
     updatePose = gazebo::event::Events::ConnectWorldUpdateBegin(
@@ -128,7 +128,7 @@ TurtlebotSensors::_on_cam(int id){
         uint32_t w = cam[id]->ImageWidth();
         img[id] = cv::Mat(h, w, CV_8UC3, (uint8_t*)data);
 
-        cam[id]->DisconnectUpdated(sub_cam[id]); // close connection
+        // cam[id]->DisconnectUpdated(sub_cam[id]); // close connection
      }
 }
 
@@ -185,5 +185,5 @@ TurtlebotSensors::_on_bumper(){
 
 void
 TurtlebotSensors::OnUpdate(const gazebo::common::UpdateInfo & /*_info*/){
-    pose = model->GetWorldPose();
+    pose = model->WorldPose();
 }


### PR DESCRIPTION
Hello,

Ubuntu 18.04 only supports Gazebo 9 and above. So changed the Gazebo API being used to support Gazebo 9 and above.

Also, Ice 3.6 is not supported for Ubuntu 18.04, and for Ice3.7 some CMakeList files had to be changed to remove IceUtil.

Kindly test and review.