### PR TITLE
Remove node intialization from cmdvel_publisher (ROS)

### DIFF
--- a/src/libs/comm_py/comm/ros/publisherCmdVel.py
+++ b/src/libs/comm_py/comm/ros/publisherCmdVel.py
@@ -43,7 +43,6 @@ class PublisherCMDVel:
         @type jdrc: jderobot Communicator
 
         '''
-        rospy.init_node("ss")
         self.topic = topic
         self.jdrc = jdrc
         self.vel = CMDVel()


### PR DESCRIPTION
This causes problems using the comm package in RoboticsAcademy  Exercises. In general,publishers/subscribers should not be initializing a new node as they are already called by a ROS node.