### PR TITLE
Removed entry for JdeRobotKids.py

### DIFF
--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -145,6 +145,8 @@ endif(NOT DEFINED SLICE_NEW_STYLE)
 #                 #
 ###################
 
+INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/python/Kibotics.py DESTINATION ${JDEROBOT_PYTHON_MODULE_PATH} COMPONENT interfaces)
+
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libJderobotInterfaces.so DESTINATION ${CMAKE_INSTALL_PREFIX}/lib COMPONENT interfaces )
 
 # Install python files

--- a/src/interfaces/CMakeLists.txt
+++ b/src/interfaces/CMakeLists.txt
@@ -145,8 +145,6 @@ endif(NOT DEFINED SLICE_NEW_STYLE)
 #                 #
 ###################
 
-INSTALL(FILES ${CMAKE_CURRENT_SOURCE_DIR}/python/JdeRobotKids.py DESTINATION ${JDEROBOT_PYTHON_MODULE_PATH} COMPONENT interfaces)
-
 INSTALL(FILES ${CMAKE_CURRENT_BINARY_DIR}/libJderobotInterfaces.so DESTINATION ${CMAKE_INSTALL_PREFIX}/lib COMPONENT interfaces )
 
 # Install python files


### PR DESCRIPTION
Fixes #1373 : When #1370  was merged, the entry in the CMakeLists for JdeRobotKids.py was not deleted. This results in an error in the sudo make install command. This pull request fixes the error by removing the entry for JdeRobotKids.py